### PR TITLE
added Actitivies page to keep track of what we've done

### DIFF
--- a/activities.html
+++ b/activities.html
@@ -12,7 +12,6 @@
 <script> 
 $(function(){
   $("#head").load("head.html"); 
-  $("#side").load("side.html"); 
   $("#recent").load("recent.html"); 
   $("#past").load("past.html"); 
 });

--- a/head.html
+++ b/head.html
@@ -15,6 +15,7 @@
    <li><a href="about.html">About Us</a></li>
    <li><a href="http://datacarpentry.github.io/blog/">Blog</a></li>
    <li><a href="lesson-dev.html">Lessons</a></li>
+   <li><a href="activities.html">Activities</a></li>
    <li><a href="contact.html">Contact Us</a></li>
    </ul>
 </div><!-- end nav -->

--- a/recent.html
+++ b/recent.html
@@ -1,4 +1,16 @@
 
+
+<div id="col1" class="grid_8">
+<p>
+Data Carpentry workshop at <a href=https://github.com/datacarpentry/2015-04-23-stanford/wiki/Stanford-Data-Carpentry-2015-04-23>Stanford</a> with instructors Amy Hodge and Tracy Teal
+</div>
+
+<div id="col1" class="grid_8">
+<p>
+Greg Wilson and Tracy Teal give presentation on Software Carpentry and 
+Data Carpentry at XSEDE Campus Champions meeting on April 21, 2015.
+</div> 
+
 <div id="col1" class="grid_8">
 <p>
 Post on the recent Data Carpentry Genomics and Assessment Hackathon <b>by Kate Hertweck</b>


### PR DESCRIPTION
I wanted to keep track of blog posts, workshops, talks and other activities we're involved in and let people know about them, so I started an 'Activities' page. activities.html is just a shell that pulls in content from past.html and recent.html  The idea is that past.html is more archival (and still needs to be updated) and recent.html are the more recent activities, where we can add more description. 
